### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop  # or the branch you want to monitor for pull requests
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MineralStudios/NametagAPI/security/code-scanning/1](https://github.com/MineralStudios/NametagAPI/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out code and builds it, it only needs `contents: read` permission. This ensures that the workflow adheres to the principle of least privilege and mitigates potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
